### PR TITLE
Fix deploy css problem

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,4 @@
-baseURL       : https://geocat.ucar.edu/
+baseURL       : https://jukent.github.io/geocat-hugo/
 languageCode  : en-us
 title         : "GeoCAT| Geoscience Community Analysis Toolkit"
 theme         : ncar


### PR DESCRIPTION
The deploy was trying to pull css from the configured `baseURL` in `conf.yml`

![image](https://github.com/user-attachments/assets/affc240f-a520-4b24-92c6-3f3df8ae5ae1)

See https://anissazacharias.com/geocat-hugo/ to see my fork's deploy working