### PR TITLE
Changes for hosting website at ncar.github.io instead of jukent.github.io

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -15,7 +15,7 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-    if: github.repository == 'jukent/geocat-hugo'
+    if: github.repository == 'NCAR/geocat-hugo'
     steps:
 
       - name: Checkout repository
@@ -36,4 +36,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
-          cname: jukent.github.io/geocat-hugo
+          cname: ncar.github.io/geocat-hugo

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ public
 resources/
 .hugo_build.lock
 ARCHIVED/
+.vscode/

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,4 @@
-baseURL       : https://jukent.github.io/geocat-hugo/
+baseURL       : https://ncar.github.io/geocat-hugo/
 languageCode  : en-us
 title         : "GeoCAT| Geoscience Community Analysis Toolkit"
 theme         : ncar

--- a/content/software/geocat_applications.md
+++ b/content/software/geocat_applications.md
@@ -8,4 +8,4 @@ repo    : "https://github.com/NCAR/geocat-applications"
 image  : "images/backgrounds/applications.png"
 ---
 
-GeoCAT Applications is a community resource inspired by the NCL Applications page.
+GeoCAT Applications is a community resource managed by the GeoCAT team. Inspired by the NCL Applications page, it is designed to be a quick reference demonstrating capabilities within the scientific Python ecosystem that may be relevant to your geoscience workflows.

--- a/content/software/wrf_python.md
+++ b/content/software/wrf_python.md
@@ -1,5 +1,5 @@
 ---
-title  : "WRF-python"
+title  : "WRF-Python"
 date   : 2022-05-03T09:23:17-06:00
 type   : software
 tagline: "WRF-Python"

--- a/data/maintenance.yml
+++ b/data/maintenance.yml
@@ -11,7 +11,7 @@ items  :
   - package: "PyNGL"
     url: ./pyngl/
     image  : "images/backgrounds/geocat-curly.png"
-  - package: "wrf-python"
+  - package: "WRF-Python"
     url: ./wrf_python/
     image  : "images/backgrounds/wrf.png"
   - package: "GeoCAT-f2py"


### PR DESCRIPTION
We may eventually want to change the URL for the site, but these are the changes required now that the repo has been transferred to the NCAR organization.