### PR TITLE
AMS 2025 edits

### DIFF
--- a/content/news/ams2025.md
+++ b/content/news/ams2025.md
@@ -9,8 +9,8 @@ feature_image: "images/news/ams2025.png"
 
 Join us for “Data Visualization in Python: Leveraging Community Tools for Earth System Science Across Scales” a hybrid short course at the 105th AMS Annual Meeting on January 12, 2025 from 8:00 AM - 12:00 PM CST at the New Orleans Ernest N. Morial Convention Center or online.
 <!--more-->
-Data visualization is a crucial component of the scientific process. With the growing complexity of Earth System science data, it is crucial to stay abreast of the latest advancements in tools and techniques. This half day short course will introduce participants to open-source tools and resources (GeoCAT and Project Pythia) and leveraging open-source, community software from the scientific Python ecosystem (e.g. Matplotlib, Cartopy, Holoviews, and UXarray). 
+Data visualization is a crucial component of the scientific process. With the growing complexity of Earth System science data, it is crucial to stay abreast of the latest advancements in tools and techniques. This half day short course guides participants through a range of tools, techniques, and resources (e.g. Project Pythia, GeoCAT) for visualization of Earth System science data across scales leveraging open-source software from the scientific Python ecosystem (e.g. Matplotlib, Cartopy, Holoviews, Geoviews, UXarray).
 
-The course covers advanced techniques, including domain-specific plots, animations, interactive tools, and visualization of data on unstructured grids. 
+The course covers advanced techniques, including domain-specific plots, animations, interactive tools, and visualization of data on unstructured grids.
 
 [Read more and register on the AMS course website!](https://www.ametsoc.org/index.cfm/ams/education-careers/careers/professional-development/short-courses/data-visualization-in-python-leveraging-community-tools-for-earth-system-science-across-scales1/)

--- a/content/news/ams2025.md
+++ b/content/news/ams2025.md
@@ -13,4 +13,4 @@ Data visualization is a crucial component of the scientific process. With the gr
 
 The course covers advanced techniques, including domain-specific plots, animations, interactive tools, and visualization of data on unstructured grids. 
 
-[Read more and register on the AMS course website](https://www.ametsoc.org/index.cfm/ams/education-careers/careers/professional-development/short-courses/data-visualization-in-python-leveraging-community-tools-for-earth-system-science-across-scales1/)
+[Read more and register on the AMS course website!](https://www.ametsoc.org/index.cfm/ams/education-careers/careers/professional-development/short-courses/data-visualization-in-python-leveraging-community-tools-for-earth-system-science-across-scales1/)

--- a/content/news/ams2025.md
+++ b/content/news/ams2025.md
@@ -7,7 +7,7 @@ image: "images/news/ams2025.png"
 feature_image: "images/news/ams2025.png"
 ---
 
-Join us for “Data Visualization in Python: Leveraging Community Tools for Earth System Science Across Scales” a hybrid short course at the 105th AMS Annual Meeting on January 12, 2025 from 8:00 AM - 12:00 PM CST at the New Orleans Ernest N. Morial Convention Center or online.
+Join us for “Data Visualization in Python: Leveraging Community Tools for Earth System Science Across Scales” a hybrid short course at the 105th AMS Annual Meeting on January 12, 2025 from 8:00 AM - 12:00 PM CST at the New Orleans Ernest N. Morial Convention Center and online.
 <!--more-->
 Data visualization is a crucial component of the scientific process. With the growing complexity of Earth System science data, it is crucial to stay abreast of the latest advancements in tools and techniques. This half day short course guides participants through a range of tools, techniques, and resources (e.g. Project Pythia, GeoCAT) for visualization of Earth System science data across scales leveraging open-source software from the scientific Python ecosystem (e.g. Matplotlib, Cartopy, Holoviews, Geoviews, UXarray).
 

--- a/content/news/ams2025.md
+++ b/content/news/ams2025.md
@@ -7,10 +7,10 @@ image: "images/news/ams2025.png"
 feature_image: "images/news/ams2025.png"
 ---
 
-Join us for “Data Visualization in Python: Leveraging Community Tools for Earth System Science Across Scales” at the AMS 105th Annual Meeting on January 12, 2025 at 8:00 AM - 12:00 PM Central Time (Hybrid) at the place New Orleans Ernest N. Morial Convention Center.
+Join us for “Data Visualization in Python: Leveraging Community Tools for Earth System Science Across Scales” a hybrid short course at the 105th AMS Annual Meeting on January 12, 2025 from 8:00 AM - 12:00 PM CST at the New Orleans Ernest N. Morial Convention Center or online.
 <!--more-->
-Data visualization is a crucial component of the scientific process. With the growing complexity of Earth System science data, it is crucial to stay abreast of the latest advancements in tools and techniques for Python scientific visualization. This half day “short course” at the 105th annual AMS meeting will introduce participants to open-source tools and resources (GeoCAT and Project Pythia) and demonstrate several cutting edge plotting libraries (e.g., Matplotlib, Cartopy, Holoviews). 
+Data visualization is a crucial component of the scientific process. With the growing complexity of Earth System science data, it is crucial to stay abreast of the latest advancements in tools and techniques. This half day short course will introduce participants to open-source tools and resources (GeoCAT and Project Pythia) and leveraging open-source, community software from the scientific Python ecosystem (e.g. Matplotlib, Cartopy, Holoviews, and UXarray). 
 
-The course covers advanced techniques, including domain-specific plots, animations, interactive tools, and visualization of data on unstructured grids, to address typical challenges in Earth System science. 
+The course covers advanced techniques, including domain-specific plots, animations, interactive tools, and visualization of data on unstructured grids. 
 
-[Read the full course description or view the agenda at the AMS website](https://www.ametsoc.org/index.cfm/ams/education-careers/careers/professional-development/short-courses/data-visualization-in-python-leveraging-community-tools-for-earth-system-science-across-scales1/)
+[Read more and register on the AMS course website](https://www.ametsoc.org/index.cfm/ams/education-careers/careers/professional-development/short-courses/data-visualization-in-python-leveraging-community-tools-for-earth-system-science-across-scales1/)


### PR DESCRIPTION
Some minor edits to the AMS 2025 blog post to make it more clear it's hybrid (remote / in-person), indicate that you can now register on the AMS site, and adjust the language so it's a bit closer to the abstract.

Honestly, I could take or leave most of these.  

The original looks really nice - thanks for putting that together!

Closes #17